### PR TITLE
Few Patches & Reduce `vAPI` reliance on DOM API

### DIFF
--- a/platform/chromium/patches.js
+++ b/platform/chromium/patches.js
@@ -1,4 +1,3 @@
-class HTMLDivElement {}
 class HTMLDocument {
 	currentScript = {
 		src: chrome.runtime.getURL("/js/background.sw.js"),
@@ -6,23 +5,12 @@ class HTMLDocument {
 	title = "uBlock Origin Background Page";
 
 	createElement(type) {
-		if (type === "div")
-			return new HTMLDivElement();
-		throw "a";
-	}
-}
-class CSS {
-	static supports(selector) {
-		console.log("supports", selector);
-		return true;
+		throw new TypeError("HTMLDocument.createElement is not implemented");
 	}
 }
 
-globalThis.HTMLDivElement = HTMLDivElement;
 globalThis.HTMLDocument = HTMLDocument;
-globalThis.XMLDocument = class { };
 globalThis.Element = class { };
-globalThis.CSS = CSS;
 globalThis.document = new HTMLDocument();
 globalThis.window = globalThis;
 

--- a/platform/common/vapi-common.js
+++ b/platform/common/vapi-common.js
@@ -176,9 +176,17 @@ vAPI.webextFlavor = {
         soup.add('mobile');
     }
 
-    if ( CSS.supports('selector(a:has(b))') ) {
+    // [PATCH uBlock-mv3] @SukkaW
+    //
+    // All modern Browsers suppoert `:has()` selector. As for Firefox users:
+    // - Firefox won't even use our fork, they all use native uBO
+    // - Even if they do this this fork, they probably are running Firefox 121+ anyway
+    //
+    // Thus, we can simply skip this check
+    //
+    // if ( CSS.supports('selector(a:has(b))') ) {
         soup.add('native_css_has');
-    }
+    // }
 
     const extensionOrigin = browser.runtime.getURL('');
 

--- a/platform/common/vapi.js
+++ b/platform/common/vapi.js
@@ -25,7 +25,24 @@
 
 if (
     self.browser instanceof Object &&
-    self.browser instanceof Element === false
+    // [PATCH uBlock-mv3] @SukkaW
+    //
+    // uBO add this check to circumvent a specific issue:
+    // contentscript is injected directly into the DOM, but what if
+    // there is a <div id="broswer" /> that can also register self.browser?
+    //
+    // See https://github.com/uBlockOrigin/uBlock-issues/issues/1914
+    //
+    // However, we don't have this issue in the very first place, as we are in
+    // a Service Worker and there is no DOM pollution.
+    //
+    // self.browser instanceof Element === false
+    typeof self.browser === "object" &&
+    (
+        typeof Element === "function"
+            ? (self.browser instanceof Element === false)
+            : (true)
+    )
 ) {
     self.chrome = self.browser;
 } else {
@@ -49,14 +66,23 @@ var vAPI = self.vAPI; // jshint ignore:line
 //   Skip text/plain documents.
 
 if (
-    (
-        document instanceof HTMLDocument ||
-        document instanceof XMLDocument &&
-        document.createElement('div') instanceof HTMLDivElement
-    ) &&
-    (
-        /^image\/|^text\/plain/.test(document.contentType || '') === false
-    ) &&
+    // [PATCH uBlock-mv3] @SukkaW
+    //
+    // uBO include this check to skip itself on Chrome's JSON/XML/Text code view.
+    //
+    // For us, Service Worker do not have DOM, so we can just remove this detection for now.
+    //
+    // TODO: We probably still need to find a way to skip uBO on JSON/XML/Text code view,
+    // maybe via OffscreenDocument?
+    //
+    // (
+    //     document instanceof HTMLDocument ||
+    //     document instanceof XMLDocument &&
+    //     document.createElement('div') instanceof HTMLDivElement
+    // ) &&
+    // (
+    //     /^image\/|^text\/plain/.test(document.contentType || '') === false
+    // ) &&
     (
         self.vAPI instanceof Object === false || vAPI.uBO !== true
     )

--- a/platform/common/vapi.js
+++ b/platform/common/vapi.js
@@ -66,24 +66,25 @@ var vAPI = self.vAPI; // jshint ignore:line
 //   Skip text/plain documents.
 
 if (
-    // [PATCH uBlock-mv3] @SukkaW
+    // [PATCH uBlock-mv3 START] @SukkaW
     //
     // uBO include this check to skip itself on Chrome's JSON/XML/Text code view.
     //
-    // For us, Service Worker do not have DOM, so we can just remove this detection for now.
-    //
-    // TODO: We probably still need to find a way to skip uBO on JSON/XML/Text code view,
-    // maybe via OffscreenDocument?
-    //
-    // (
-    //     document instanceof HTMLDocument ||
-    //     document instanceof XMLDocument &&
-    //     document.createElement('div') instanceof HTMLDivElement
-    // ) &&
-    // (
-    //     /^image\/|^text\/plain/.test(document.contentType || '') === false
-    // ) &&
+    // For us, Service Worker do not have DOM, so we short circuit Service Worker here
     (
+        (
+            typeof ServiceWorkerGlobalScope !== "undefined"
+        ) || (
+            (
+                document instanceof HTMLDocument ||
+                document instanceof XMLDocument &&
+                document.createElement('div') instanceof HTMLDivElement
+            ) &&
+            (
+                /^image\/|^text\/plain/.test(document.contentType || '') === false
+            )
+        )
+    ) && (
         self.vAPI instanceof Object === false || vAPI.uBO !== true
     )
 ) {


### PR DESCRIPTION
The sole reason we need `patches.js` is that there is no DOM (and DOM-related Web API like `requestIdleCallback`) in the Service Worker, where the `vAPI` core needs them.

However, instead of mocking a DOM, we can patch the `vAPI` core to avoid the DOM check:

- Drop `createElement` mock: related vAPI init guard is commented out
- Drop `XMLDocument` mock: related vAPI init guard is commented out
- Drop `CSS.supports` mock: we assume the `:has` selector is supported by default

~~The PR also updates the homepage HTML to include a potential way to specify `ExtensionInstallForcelist` on macOS using `defaults write` (This is similar to old Chrome 136~139 days when people used `defaults write com.google.Chrome ExtensionManifestV2Availability -int 2` to force enable MV2 extension).~~