### PR TITLE
Bug report - extension wholly unusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">
+<h1 align="center" >
 <sub>
 <img src="https://github.com/gorhill/uBlock/blob/master/src/img/ublock.svg" height="38" width="38">
 </sub>


### PR DESCRIPTION
I am forced to submit a bug report like this because the "new issue" page has been completely gutted and only leads to other projects/pages. (Which I guess is often valid, but not this time.)

I can only assume that something was recently broken, but as of 1.72.2 this MV3 version of the extension does literally nothing. Installed to both Chrome (149.0.7827.54, via managed browser settings), and Vivaldi (8.1.4087.48, based on Chromium 150.0.7871.120), and while the icon appears and you can access settings, the extension does not block anything regardless of what filters are set. User scripts have been enabled and this fact is validated by the extension icon.

One telltale sign is that in the dynamic rule panel on the left, the third-party domains accessed by the current site are not listed, only the main domain appears - the extension simply does not know about what is happening. And even if the main domain is explicitly blocked on the panel, JS continues to load and run.

The MV2 extension (same 1.72.2 version) works fine on Vivaldi (which still has MV2 extensions enabled for now). This is a problem with the port. 