### PR TITLE
Drop `Element`/`document.title` polyfill w/ init guard patch

### DIFF
--- a/platform/chromium/patches.js
+++ b/platform/chromium/patches.js
@@ -10,7 +10,6 @@ class HTMLDocument {
 }
 
 globalThis.HTMLDocument = HTMLDocument;
-globalThis.Element = class { };
 globalThis.document = new HTMLDocument();
 globalThis.window = globalThis;
 

--- a/platform/chromium/patches.js
+++ b/platform/chromium/patches.js
@@ -2,7 +2,6 @@ class HTMLDocument {
 	currentScript = {
 		src: chrome.runtime.getURL("/js/background.sw.js"),
 	}
-	title = "uBlock Origin Background Page";
 
 	createElement(type) {
 		throw new TypeError("HTMLDocument.createElement is not implemented");

--- a/platform/common/vapi.js
+++ b/platform/common/vapi.js
@@ -27,21 +27,18 @@ if (
     self.browser instanceof Object &&
     // [PATCH uBlock-mv3] @SukkaW
     //
-    // uBO add this check to circumvent a specific issue:
-    // contentscript is injected directly into the DOM, but what if
-    // there is a <div id="broswer" /> that can also register self.browser?
-    //
+    // uBO's `self.browser instanceof Element` check guards against DOM
+    // pollution (e.g. <div id="browser" />).
     // See https://github.com/uBlockOrigin/uBlock-issues/issues/1914
     //
-    // However, we don't have this issue in the very first place, as we are in
-    // a Service Worker and there is no DOM pollution.
-    //
-    // self.browser instanceof Element === false
-    typeof self.browser === "object" &&
+    // In MV3 the Service Worker is the only no-DOM context that loads this
+    // file (content scripts, popup, and dashboard pages all have a real DOM).
+    // So we short-circuit with a ServiceWorkerGlobalScope check, and fall
+    // back to the original Element check for content-script contexts where
+    // DOM pollution is still possible.
     (
-        typeof Element === "function"
-            ? (self.browser instanceof Element === false)
-            : (true)
+        typeof ServiceWorkerGlobalScope !== "undefined" ||
+        self.browser instanceof Element === false
     )
 ) {
     self.chrome = self.browser;

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -21,9 +21,22 @@
 
 /******************************************************************************/
 
+// [PATCH uBlock-mv3] @SukkaW
+//
+// uBO's `self.browser instanceof Element` check guards against DOM pollution
+// (e.g. <div id="browser" />). See https://github.com/uBlockOrigin/uBlock-issues/issues/1914
+//
+// In MV3 the Service Worker is the only no-DOM context that loads this file
+// (content scripts, popup, and dashboard pages all have a real DOM). So we
+// short-circuit with a ServiceWorkerGlobalScope check, and fall back to the
+// original Element check for content-script contexts where DOM pollution is
+// still possible.
 const i18n =
     self.browser instanceof Object &&
-    self.browser instanceof Element === false
+    (
+        typeof ServiceWorkerGlobalScope !== "undefined" ||
+        self.browser instanceof Element === false
+    )
         ? self.browser.i18n
         : self.chrome.i18n;
 

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -44,7 +44,18 @@ const i18n$ = (...args) => i18n.getMessage(...args);
 
 /******************************************************************************/
 
-const isBackgroundProcess = document.title === 'uBlock Origin Background Page';
+// [PATCH uBlock-mv3] @SukkaW
+//
+// In MV2, uBO detects the background page by checking document.title against
+// the <title> of background.html. In MV3 there is no background.html — the
+// background is a Service Worker. We detect if we are in SW directly, if so
+// we are "background process".
+//
+// Once again, in MV3 the Service Worker is the only no-DOM context that loads
+// this file, so we short-circuit with a ServiceWorkerGlobalScope check
+const isBackgroundProcess =
+    typeof ServiceWorkerGlobalScope !== "undefined" ||
+    document.title === 'uBlock Origin Background Page';
 
 if ( isBackgroundProcess !== true ) {
 


### PR DESCRIPTION
The PR follows #2 by dropping `Element`/`document.title` polyfills.

This PR touches another 2 init guards that gorhill hasn't touched for 4~7 years.

The idea is that the Service Worker is the only context where we have no DOM. Popup, OffScreenDocument, and Content Script all have a DOM. We can just `typeof ServiceWorkerGlobalScope` and short-circuit everything.

